### PR TITLE
reduce size of about button because it covers the headline on smaller…

### DIFF
--- a/style.css
+++ b/style.css
@@ -57,7 +57,7 @@ body {
 }
 
 #about-button {
-	width: 100px;
+	width: 70px;
 	position: absolute;
 	top: 10px;
 	right: 5px;


### PR DESCRIPTION
… devices